### PR TITLE
chore: configure workspace with test runner and WASM test modules

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -391,6 +391,7 @@ pub enum LoadPackageError {
     PackageCycle {
         cycle: Vec<PackageId>,
     },
+    #[snafu(display("Package {} not found", package_name))]
     MissingPackage {
         package_name: String,
     },
@@ -420,6 +421,12 @@ pub enum InstantiatePackageError {
         source: anyhow::Error,
     },
     InvalidTrampolineSynchronicity,
+    #[snafu(display(
+        "Missing interface {}@{:?} in package {}",
+        interface_name,
+        package_version,
+        package_name
+    ))]
     MissingInterface {
         package_name: String,
         package_version: Option<Version>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_family = "wasm"))]
+
 mod graph;
 mod path;
 mod semver;

--- a/tests/runner/build.sh
+++ b/tests/runner/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+cargo build --target wasm32-unknown-unknown --release --workspace
+
+for x in kvstore logger application; do
+  wasm-tools component new \
+    target/wasm32-unknown-unknown/release/$x.wasm > target/wasm32-unknown-unknown/release/$x.component.wasm
+done
+
+cargo run -p runner

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -1,6 +1,106 @@
-fn main() {
-    // TODO(dplecki): Accept CLI arguments for WASM files to load into the crate's composition
-    //  graph, then execute a well-known entrypoint within the "main" package specified in the
-    //  arguments.
-    todo!()
+#[cfg(target_family = "wasm")]
+fn main() {}
+
+#[cfg(not(target_family = "wasm"))]
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    runner::main().await
+}
+
+#[cfg(not(target_family = "wasm"))]
+mod runner {
+    use semver::Version;
+    use std::path::Path;
+    use std::sync::Arc;
+    use tokio::fs;
+    use wac_trampoline::{AsyncTrampoline, CompositionGraph};
+    use wasmtime::{Config, Engine, Store, component::Linker};
+
+    // Define our store data type
+    #[derive(Debug)]
+    struct AppData {
+        // We could add application-specific data here if needed
+    }
+
+    // Simple async trampoline that just passes calls through
+    struct PassthroughTrampoline /*<C: Clone + Sync + Send + 'static>*/ {}
+
+    impl AsyncTrampoline<AppData, ()> for PassthroughTrampoline {}
+
+    // TODO(bill): directory from command line
+    const WASM_DIR: &str = "target/wasm32-unknown-unknown/release/";
+    //
+    // TODO(bill): packages from command line
+    async fn add_package(
+        graph: &mut CompositionGraph<AppData>,
+        path: &str,
+        name: &str,
+        version: Version,
+    ) -> Result<wac_trampoline::PackageId, wac_trampoline::AddPackageError> {
+        eprintln!("Loading {path} component...");
+        let wasm_dir = Path::new(WASM_DIR);
+        let wasm_file = format!("{path}.component.wasm").to_string();
+        let pkg_bytes = fs::read(wasm_dir.join(&wasm_file))
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Failed to read {}/{wasm_file} Make sure it's been compiled",
+                    wasm_dir.display()
+                )
+            });
+
+        let trampoline: Arc<dyn AsyncTrampoline<AppData, ()>> = Arc::new(PassthroughTrampoline {});
+        let pkg = wac_trampoline::PackageTrampoline::with_default_context(trampoline, ());
+
+        let ret = graph.add_package(name.to_string(), version, pkg_bytes, pkg);
+        eprintln!("{name} component loaded successfully.");
+        ret
+    }
+
+    pub async fn main() -> anyhow::Result<()> {
+        let verbose = false; // TODO(bill): command line option
+        // Configure the WebAssembly engine
+        let mut config = Config::new();
+        config.wasm_component_model(true);
+        config.async_support(true);
+
+        let engine = Engine::new(&config)?;
+        let mut linker = Linker::new(&engine);
+        let mut store = Store::new(&engine, AppData {});
+
+        // Create our composition graph
+        let mut graph = CompositionGraph::<AppData>::new();
+        // Load the logger component
+        add_package(&mut graph, "logger", "test:logging", Version::new(1, 1, 1)).await?;
+
+        // Load the KV store component
+        let _kvstore_id =
+            add_package(&mut graph, "kvstore", "test:kvstore", Version::new(2, 1, 6)).await?;
+
+        // Load the application component
+        let app_id = add_package(
+            &mut graph,
+            "application",
+            "test:application",
+            Version::new(0, 4, 0),
+        )
+        .await?;
+
+        // Instantiate the components
+        eprintln!("Instantiating components...");
+        if verbose {
+            eprintln!("graph: {graph:#?}");
+        }
+        graph
+            .instantiate(app_id, &mut linker, &mut store, &engine)
+            .await?;
+        eprintln!("Components instantiated successfully.");
+
+        // TODO: Add code to interact with the instantiated components
+        // This would require generating bindings for the interfaces or using
+        // the low-level Wasmtime API to call the exported functions
+
+        println!("Test completed successfully!");
+        Ok(())
+    }
 }

--- a/tests/wasm/kvstore/src/lib.rs
+++ b/tests/wasm/kvstore/src/lib.rs
@@ -13,7 +13,7 @@ static GLOBAL_MAP: LazyLock<Mutex<HashMap<String, String>>> =
 pub struct Store;
 
 impl exports::test::kvstore::store::Guest for Store {
-    fn set(key: String, value: String) -> () {
+    fn set(key: String, value: String) {
         if let Ok(mut map) = GLOBAL_MAP.lock() {
             map.insert(key, value);
         }

--- a/tests/wasm/logger/src/lib.rs
+++ b/tests/wasm/logger/src/lib.rs
@@ -4,8 +4,8 @@ wit_bindgen::generate!();
 pub struct Logger;
 
 impl exports::test::logging::logger::Guest for Logger {
-    fn log(_msg: String) {
-        todo!()
+    fn log(msg: String) {
+        println!("[LOGGER] {}", msg);
     }
 }
 export!(Logger);


### PR DESCRIPTION
feat: Implement test runner with component loading and instantiation

- arc  global_map

- export components

- split dependencies along wasm/unix

build: test runner for WebAssembly components

This commit adds:
- Updated Cargo.toml with necessary dependencies
- Main test runner implementation
- Build script for WebAssembly components
- Logger implementation with actual logging
- Passthrough trampolines for component dependencies

The test runner now:
1. Configures a WebAssembly engine
2. Loads logger, kvstore, and application components
3. Creates a composition graph
4. Instantiates components with their dependencies
5. Provides a framework for future component interaction

Requires further work to:
- Generate precise interface bindings
- Add more sophisticated trampoline handling
- Implement specific component interaction logic
