### PR TITLE
chore(devenv): refine cargo commands

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -15,14 +15,9 @@
 
   languages.rust.enable = true;
 
-  processes =
-    {
-    }
-    // lib.optionalAttrs (config.devenv.isTesting) {
-    }
-    // lib.optionalAttrs (!config.devenv.isTesting) {
-      cargo-watch.exec = "cargo-watch";
-    };
+  processes = lib.optionalAttrs (!config.devenv.isTesting) {
+    cargo-watch.exec = "cargo-watch";
+  };
 
   enterTest = ''
     cargo test --workspace


### PR DESCRIPTION
- use workspace and all for check/fmt
- only use cargo-check in development mode
