### PR TITLE
Add lld and wasm-tools pkgs to devenv

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -6,9 +6,11 @@
 }:
 
 {
-  packages = [
-    pkgs.cargo-watch
-    pkgs.git
+  packages = with pkgs; [
+    cargo-watch
+    git
+    lld
+    wasm-tools
   ];
 
   languages.rust.enable = true;


### PR DESCRIPTION
These packages are required for the new wasm component compilation integration test