### PR TITLE
Fix CI runs on push

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ name: "Run Tests"
 on:
   pull_request:
   push:
-    branches: [ $default_branch ]
+    branches: [ master ]
 
 jobs:
   tests:


### PR DESCRIPTION
The $default_branch injection doesn't seem to be working, use `master`
instead.