### PR TITLE
chore(cargo): use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ members = [
 
 [package]
 name = "wasm-trampoline"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+
+[workspace.package]
 authors = ["ANDYL Open Source <oss@andyl.com>"]
 version = "0.1.0"
 edition = "2024"
@@ -20,17 +25,19 @@ async = [
     "wasmtime/component-model-async",
 ]
 
-[dependencies]
+[workspace.dependencies]
 anyhow = "1"
 derivative = "2"
 semver = "1"
+wasmtime = { version = "33", features = ["component-model"] }
+wit-bindgen = "0.42"
 
 [target.'cfg(unix)'.dependencies]
-anyhow = "1"
-derivative = "2"
-semver = "1"
+anyhow.workspace = true
+derivative.workspace = true
+semver.workspace = true
 indexmap = "2"
 slab = "0.4"
 snafu = "0.8"
 wac-types = "0.6"
-wasmtime = { version = "33", features = ["component-model"] }
+wasmtime.workspace = true

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "runner"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-anyhow = "1.0"
-semver = "1.0"
+anyhow.workspace = true
+semver.workspace = true
 tokio = { version = "1.0", features = ["full"] }
-wasmtime = { version = "33", features = ["component-model", "async"] }
+wasmtime = { workspace = true, features = ["component-model", "async"] }
 wasmtime-wasi = { version = "33" }
 wasm-trampoline = { path = "../.." }

--- a/tests/wasm/application/Cargo.toml
+++ b/tests/wasm/application/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "application"
 version = "0.4.0"
-edition = "2024"
+edition.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.42"
+wit-bindgen.workspace = true

--- a/tests/wasm/kvstore/Cargo.toml
+++ b/tests/wasm/kvstore/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "kvstore"
 version = "2.1.6"
-edition = "2024"
+edition.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.42"
+wit-bindgen.workspace = true

--- a/tests/wasm/logger/Cargo.toml
+++ b/tests/wasm/logger/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "logger"
 version = "1.0.0"
-edition = "2024"
+edition.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.42"
+wit-bindgen.workspace = true


### PR DESCRIPTION
# Workspace Configuration Refactoring

This PR refactors the project to use a proper workspace configuration, improving dependency management and consistency across crates. Key changes include:

- Added workspace-level package metadata (authors, edition, version)
- Moved common dependencies to workspace.dependencies section
- Updated all crates to use workspace inheritance for edition and dependencies
- Simplified dependency specifications by removing duplicate version declarations
- Used workspace references for common dependencies like anyhow, semver, wasmtime, and wit-bindgen
- Applied consistent edition configuration across all packages

This change makes the project structure more maintainable by centralizing dependency versions and package metadata, reducing duplication and making future updates easier.