### PR TITLE
fix(gha):  inform actionlint of runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-latest-16
+    - ubuntu-latest-32


### PR DESCRIPTION
Added actionlint configuration for self-hosted runners

This PR adds a new `.github/actionlint.yaml` configuration file that defines the allowed self-hosted runner labels. The configuration specifies two valid runner labels:
- `ubuntu-latest-16`
- `ubuntu-latest-32`

This change will help validate GitHub Actions workflows that use these specific self-hosted runner configurations.