### PR TITLE
chore(deps): update devenv dependencies

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1746707904,
+        "lastModified": 1748361913,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "fada79d97f2066c444766d039b0a62affd3e3cab",
+        "rev": "b510085f1ca92779782d1e3de631b2292a30edb2",
         "type": "github"
       },
       "original": {
@@ -19,10 +19,10 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
+        "lastModified": 1747046372,
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -40,10 +40,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1746537231,
+        "lastModified": 1747372754,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "fa466640195d38ec97cf0493d6d6882bc4d14969",
+        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Update devenv dependencies

This PR updates the following dependencies:
- `devenv` from `fada79d97f2066c444766d039b0a62affd3e3cab` to `b510085f1ca92779782d1e3de631b2292a30edb2`
- `flake-compat` from `ff81ac966bb2cae68946d5ed5fc4994f96d0ffec` to `9100a0f413b0c601e0533d1d94ffd501ce2e7885`
- `git-hooks.nix` from `fa466640195d38ec97cf0493d6d6882bc4d14969` to `80479b6ec16fefd9c1db3ea13aeb038c60530f46`