### PR TITLE
feat(gha): add sccache to test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   tests:
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     strategy:
       matrix:
         os: [ ubuntu-latest-16 ]
@@ -18,6 +21,8 @@ jobs:
       - uses: cachix/cachix-action@v14
         with:
           name: devenv
+      - name: sccache
+        uses: Mozilla-Actions/sccache-action@main
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
### TL;DR

Add sccache to GitHub Actions workflow to improve Rust build caching.

### What changed?

- Added environment variables `SCCACHE_GHA_ENABLED` and `RUSTC_WRAPPER` to enable sccache
- Integrated Mozilla's sccache-action into the workflow before the existing Rust cache step

### How to test?

Run the GitHub Actions workflow and verify that:
1. sccache is properly initialized
2. Build times improve on subsequent runs due to caching
3. The existing Rust cache continues to function alongside sccache

### Why make this change?

sccache provides more efficient caching of Rust compilation artifacts, which should reduce build times in CI. This is particularly beneficial for repeated builds of the same code, as it avoids recompiling unchanged dependencies, resulting in faster CI runs and reduced resource usage.