### PR TITLE
chore(ci): enable caching all crates and ignore coverage files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-all-crates: true
 
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ devenv.local.nix
 
 # pre-commit
 .pre-commit-config.yaml
+
+coverage.*


### PR DESCRIPTION
This PR enhances our CI/CD pipeline and testing infrastructure in two ways:

1. Enables caching for all Rust crates in the GitHub Actions workflow by adding the `cache-all-crates: true` option to the Swatinem/rust-cache action.

2. Updates the .gitignore file to exclude coverage report files by adding `coverage.*` to the ignored patterns.

These changes should improve build times and prevent coverage reports from being accidentally committed to the repository.
