### PR TITLE
chore(gha): disable incremental compilation in tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      CARGO_INCREMENTAL: "0"
     strategy:
       matrix:
         os: [ ubuntu-latest-16 ]


### PR DESCRIPTION
# Disable Incremental Compilation in CI

Disable incremental compilation in CI by setting CARGO_INCREMENTAL=0 in the test workflow environment variables.

sccache works better without incremental compilation, and it is not needed in CI.
