### PR TITLE
feat(runner): add async-runner for coverage testing

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -52,10 +52,11 @@
   scripts."wasm-trampoline-coverage" = {
     description = "Run wasm-trampoline-coverage";
     exec = ''
-      tests/runner/build.sh
+      tests/runner/build.sh >/dev/null
       cargo llvm-cov clean --workspace
       cargo llvm-cov test --workspace --no-report --release
       cargo llvm-cov run --bin runner -p runner --release --no-report
+      cargo llvm-cov run --bin async-runner -p runner --release --no-report
       cargo llvm-cov report --release --cobertura --output-path coverage.cobertura.xml
       cargo llvm-cov report --release --lcov --output-path coverage.lcov
     '';

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -9,3 +9,9 @@ semver.workspace = true
 tokio = { version = "1.0", features = ["full"] }
 wasmtime = { workspace = true, features = ["component-model", "async"] }
 wasm-trampoline = { path = "../.." }
+
+[[bin]]
+name = "async-runner"
+
+[[bin]]
+name = "runner"

--- a/tests/runner/build.sh
+++ b/tests/runner/build.sh
@@ -8,4 +8,5 @@ for x in kvstore logger application; do
     target/wasm32-unknown-unknown/release/$x.wasm > target/wasm32-unknown-unknown/release/$x.component.wasm
 done
 
-cargo run -p runner --release
+cargo run -p runner --bin runner --release
+cargo run -p runner --bin async-runner --release

--- a/tests/runner/src/bin/async-runner.rs
+++ b/tests/runner/src/bin/async-runner.rs
@@ -68,7 +68,7 @@ mod runner {
     }
 
     // TODO(bill): directory from command line
-    const WASM_DIR: &str = "target/wasm32-unknown-unknown/release/";
+    const WASM_DIR: &str = "wasm32-unknown-unknown/release/";
 
     // TODO(bill): packages from command line
     async fn add_package(
@@ -78,7 +78,10 @@ mod runner {
         version: Version,
     ) -> Result<wasm_trampoline::PackageId, wasm_trampoline::AddPackageError> {
         eprintln!("Loading {path} component...");
-        let wasm_dir = Path::new(WASM_DIR);
+        let wasm_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("target")
+            .join(WASM_DIR);
         let wasm_file = format!("{path}.component.wasm").to_string();
         let pkg_bytes = fs::read(wasm_dir.join(&wasm_file))
             .await

--- a/tests/runner/src/bin/runner.rs
+++ b/tests/runner/src/bin/runner.rs
@@ -1,0 +1,168 @@
+#[cfg(target_family = "wasm")]
+fn main() {
+    // This is a no-op for the wasm target, as the main function is not used.
+    eprintln!("This is a WebAssembly target, no main function to run.");
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    runner::main().await
+}
+
+#[cfg(not(target_family = "wasm"))]
+mod runner {
+    use anyhow::Error;
+    use semver::Version;
+    use std::path::Path;
+
+    use std::sync::Arc;
+    use tokio::fs;
+    use wasm_trampoline::{CompositionGraph, GuestCall, GuestResult, Trampoline};
+    use wasmtime::{Config, Engine, Store, component::Linker};
+
+    wasmtime::component::bindgen!({
+        path: "../wasm/application/wit",
+        async: false,
+    });
+
+    // Define our store data type
+    #[derive(Debug)]
+    struct AppData {
+        stack_depth: usize,
+    }
+
+    // Simple async trampoline that just passes calls through
+    struct PassthroughTrampoline {}
+    impl Trampoline<AppData, ()> for PassthroughTrampoline {
+        fn bounce<'c>(
+            &self,
+            mut call: GuestCall<'c, AppData, ()>,
+        ) -> Result<GuestResult<'c, AppData, ()>, Error> {
+            eprintln!(
+                "[{}] Bounced call '{}#{}'",
+                call.store().data().stack_depth,
+                call.interface(),
+                call.method(),
+            );
+
+            call.store_mut().data_mut().stack_depth += 1;
+
+            let mut result = call.call()?;
+
+            result.store_mut().data_mut().stack_depth -= 1;
+
+            eprintln!(
+                "[{}] Bounced return '{}#{}'",
+                result.store().data().stack_depth,
+                result.interface(),
+                result.method(),
+            );
+
+            Ok(result)
+        }
+    }
+
+    // TODO(bill): directory from command line
+    const WASM_DIR: &str = "wasm32-unknown-unknown/release/";
+
+    // TODO(bill): packages from command line
+    async fn add_package(
+        graph: &mut CompositionGraph<AppData>,
+        path: &str,
+        name: &str,
+        version: Version,
+    ) -> Result<wasm_trampoline::PackageId, wasm_trampoline::AddPackageError> {
+        eprintln!("Loading {path} component...");
+        let wasm_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("target")
+            .join(WASM_DIR);
+        let wasm_file = format!("{path}.component.wasm").to_string();
+        let pkg_bytes = fs::read(wasm_dir.join(&wasm_file))
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Failed to read {}/{wasm_file} Make sure it's been compiled",
+                    wasm_dir.display()
+                )
+            });
+
+        let trampoline: Arc<dyn Trampoline<AppData, ()>> = Arc::new(PassthroughTrampoline {});
+        let pkg = wasm_trampoline::PackageTrampoline::with_default_context(trampoline, ());
+
+        let ret = graph.add_package(name.to_string(), version, pkg_bytes, pkg);
+        eprintln!("{name} component loaded successfully.");
+        ret
+    }
+
+    pub async fn main() -> anyhow::Result<()> {
+        let verbose = false; // TODO(bill): command line option
+        // Configure the WebAssembly engine
+        let mut config = Config::new();
+        config.wasm_component_model(true);
+        config.async_support(false);
+
+        let engine = Engine::new(&config)?;
+        let mut linker = Linker::new(&engine);
+        let mut store = Store::new(&engine, AppData { stack_depth: 0 });
+
+        // Add global functions to the linker.
+        linker.root().func_wrap(
+            "println",
+            |_store: wasmtime::StoreContextMut<'_, AppData>, args: (String,)| {
+                let (message,) = args;
+                eprintln!("{}", message);
+                Ok(())
+            },
+        )?;
+
+        // Create our composition graph
+        let mut graph = CompositionGraph::<AppData>::new();
+
+        // Load the logger component
+        add_package(&mut graph, "logger", "test:logging", Version::new(1, 1, 1)).await?;
+        add_package(&mut graph, "logger", "test:logging", Version::new(1, 1, 1))
+            .await
+            .expect_err("Duplicate logger component should not be allowed");
+
+        // Load the KV store component
+        let _kvstore_id =
+            add_package(&mut graph, "kvstore", "test:kvstore", Version::new(2, 1, 6)).await?;
+
+        // Load the application component
+        let app_id = add_package(
+            &mut graph,
+            "application",
+            "test:application",
+            Version::new(0, 4, 0),
+        )
+        .await?;
+
+        // Instantiate the components
+        eprintln!("Instantiating components...");
+        if verbose {
+            eprintln!("graph: {graph:#?}");
+        }
+
+        let instance = graph.instantiate(app_id, &mut linker, &mut store, &engine)?;
+
+        eprintln!("Components instantiated successfully.");
+
+        let application = Application::new(&mut store, &instance)?;
+
+        application
+            .test_application_greeter()
+            .call_set_name(&mut store, "Dave")?;
+
+        let hello = application
+            .test_application_greeter()
+            .call_hello(&mut store)?;
+
+        println!("Greeter Output: {:?}", &hello);
+        assert_eq!(hello, "Hello Dave!");
+
+        println!("Test completed successfully!");
+        Ok(())
+    }
+}


### PR DESCRIPTION
# Add async-runner for wasm-trampoline testing

This PR adds an async version of the runner for testing wasm-trampoline. The changes include:

1. Split the existing runner into two binaries:
   - `runner.rs` (synchronous version)
   - `async-runner.rs` (new asynchronous version)

2. Updated the Cargo.toml to define both binaries explicitly

3. Modified the build script to run both runners

4. Enhanced the wasm-trampoline-coverage script to include coverage for the async-runner

5. Fixed the WASM directory path in both runners to use CARGO_MANIFEST_DIR for more reliable file loading

These changes allow testing both synchronous and asynchronous execution paths in the wasm-trampoline library.
