### PR TITLE
fix github actions

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,0 @@
-self-hosted-runner:
-  labels:
-    - ubuntu-latest-16
-    - ubuntu-latest-32

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -14,17 +14,17 @@ jobs:
   cron-coverage:
     strategy:
       matrix:
-        os: [ubuntu-latest-16]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
       - name: Setup devenv
-        uses: andyl-technologies/andyl-github-action/setup-devenv@master
+        uses: andyl-technologies/github-actions/setup-devenv@master
 
       - name: Setup Rust cache
-        uses: andyl-technologies/andyl-github-action/rust-cache@master
+        uses: andyl-technologies/github-actions/rust-cache@master
         with:
           cache-all-crates: true
           save-condition: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ name: 'Run Tests'
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [ master ]
 
 permissions:
   actions: read
@@ -18,7 +18,7 @@ jobs:
       CARGO_INCREMENTAL: '0'
     strategy:
       matrix:
-        os: [ubuntu-latest-16]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -26,10 +26,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup devenv
-        uses: andyl-technologies/andyl-github-action/setup-devenv@master
+        uses: andyl-technologies/github-actions/setup-devenv@master
 
       - name: Setup Rust cache
-        uses: andyl-technologies/andyl-github-action/rust-cache@master
+        uses: andyl-technologies/github-actions/rust-cache@master
         with:
           cache-all-crates: true
           use-ccache: true
@@ -40,17 +40,17 @@ jobs:
   coverage:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
       - name: Setup devenv
-        uses: andyl-technologies/andyl-github-action/setup-devenv@master
+        uses: andyl-technologies/github-actions/setup-devenv@master
 
       - name: Setup Rust cache
-        uses: andyl-technologies/andyl-github-action/rust-cache@master
+        uses: andyl-technologies/github-actions/rust-cache@master
 
       - name: Run coverage tests
         run: devenv shell wasm-trampoline-coverage


### PR DESCRIPTION
andyl github action repo name has changed, update uses to new name.

remove enterprise runners that cannot be used in public repos, in
preparation for making this repo public.

reformat yaml files.
