### PR TITLE
feat(runners): add command line switches to test runners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,10 +161,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "cranelift-assembler-x64"
@@ -462,6 +558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +841,7 @@ name = "runner"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "clap",
  "semver",
  "tokio",
  "wasm-component-trampoline",
@@ -898,6 +1007,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1126,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wac-types"

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -16,3 +16,6 @@ name = "async-runner"
 
 [[bin]]
 name = "runner"
+
+[dependencies]
+clap = { version = "4.5.41", features = ["derive"] }

--- a/tests/runner/build.sh
+++ b/tests/runner/build.sh
@@ -2,7 +2,7 @@
 set -ex
 
 TARGET_DIR=$(printf "%s/wasm32-unknown-unknown/release" "$(cargo metadata --no-deps --format-version 1 | jq -r '.target_directory')")
-readonly WASM_TARGET_DIR="${TARGET_DIR}"
+readonly WASM_TARGET_DIR="$TARGET_DIR"
 
 for x in kvstore logger application; do
 	cargo build --target wasm32-unknown-unknown --release -p "$x"
@@ -11,5 +11,5 @@ for x in kvstore logger application; do
 		"${WASM_TARGET_DIR}/$x.component.wasm"
 done
 
-cargo run -p runner --bin runner --release
-cargo run -p runner --bin async-runner --release
+cargo run -p runner --bin runner --release -- -w "$WASM_TARGET_DIR"
+cargo run -p runner --bin async-runner --release -- -w "$WASM_TARGET_DIR"

--- a/tests/runner/src/bin/async-runner.rs
+++ b/tests/runner/src/bin/async-runner.rs
@@ -13,6 +13,7 @@ async fn main() -> anyhow::Result<()> {
 #[cfg(not(target_family = "wasm"))]
 mod runner {
     use anyhow::Error;
+    use clap::Parser;
     use semver::Version;
     use std::path::Path;
     use std::pin::Pin;
@@ -22,6 +23,8 @@ mod runner {
         AsyncGuestCall, AsyncGuestResult, AsyncTrampoline, CompositionGraph, PackageTrampoline,
     };
     use wasmtime::{Config, Engine, Store, component::Linker};
+
+    use runner::cli::Args;
 
     wasmtime::component::bindgen!({
         path: "../wasm/application/wit",
@@ -104,6 +107,8 @@ mod runner {
     }
 
     pub async fn main() -> anyhow::Result<()> {
+        let _args = Args::parse();
+
         let verbose = false; // TODO(bill): command line option
         // Configure the WebAssembly engine
         let mut config = Config::new();

--- a/tests/runner/src/bin/async-runner.rs
+++ b/tests/runner/src/bin/async-runner.rs
@@ -15,7 +15,7 @@ mod runner {
     use anyhow::Error;
     use clap::Parser;
     use semver::Version;
-    use std::path::Path;
+    use std::path::PathBuf;
     use std::pin::Pin;
     use std::sync::Arc;
     use tokio::fs;
@@ -72,22 +72,16 @@ mod runner {
         }
     }
 
-    // TODO(bill): directory from command line
-    const WASM_DIR: &str = "wasm32-unknown-unknown/release/";
-
-    // TODO(bill): packages from command line
     async fn add_package(
         graph: &mut CompositionGraph<AppData>,
+        wasm_dir: &PathBuf,
         path: &str,
         name: &str,
         version: Version,
     ) -> Result<wasm_component_trampoline::PackageId, wasm_component_trampoline::AddPackageError>
     {
         eprintln!("Loading {path} component...");
-        let wasm_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .join("target")
-            .join(WASM_DIR);
+
         let wasm_file = format!("{path}.component.wasm").to_string();
         let pkg_bytes = fs::read(wasm_dir.join(&wasm_file))
             .await
@@ -107,9 +101,8 @@ mod runner {
     }
 
     pub async fn main() -> anyhow::Result<()> {
-        let _args = Args::parse();
+        let args = Args::parse();
 
-        let verbose = false; // TODO(bill): command line option
         // Configure the WebAssembly engine
         let mut config = Config::new();
         config.wasm_component_model(true);
@@ -133,18 +126,38 @@ mod runner {
         let mut graph = CompositionGraph::<AppData>::new();
 
         // Load the logger component
-        add_package(&mut graph, "logger", "test:logging", Version::new(1, 1, 1)).await?;
-        add_package(&mut graph, "logger", "test:logging", Version::new(1, 1, 1))
-            .await
-            .expect_err("Duplicate logger component should not be allowed");
+        add_package(
+            &mut graph,
+            &args.wasm_dir,
+            "logger",
+            "test:logging",
+            Version::new(1, 1, 1),
+        )
+        .await?;
+        add_package(
+            &mut graph,
+            &args.wasm_dir,
+            "logger",
+            "test:logging",
+            Version::new(1, 1, 1),
+        )
+        .await
+        .expect_err("Duplicate logger component should not be allowed");
 
         // Load the KV store component
-        let _kvstore_id =
-            add_package(&mut graph, "kvstore", "test:kvstore", Version::new(2, 1, 6)).await?;
+        let _kvstore_id = add_package(
+            &mut graph,
+            &args.wasm_dir,
+            "kvstore",
+            "test:kvstore",
+            Version::new(2, 1, 6),
+        )
+        .await?;
 
         // Load the application component
         let app_id = add_package(
             &mut graph,
+            &args.wasm_dir,
             "application",
             "test:application",
             Version::new(0, 4, 0),
@@ -153,7 +166,7 @@ mod runner {
 
         // Instantiate the components
         eprintln!("Instantiating components...");
-        if verbose {
+        if args.verbose {
             eprintln!("graph: {graph:#?}");
         }
 

--- a/tests/runner/src/bin/runner.rs
+++ b/tests/runner/src/bin/runner.rs
@@ -13,6 +13,7 @@ async fn main() -> anyhow::Result<()> {
 #[cfg(not(target_family = "wasm"))]
 mod runner {
     use anyhow::Error;
+    use clap::Parser;
     use semver::Version;
     use std::path::Path;
 
@@ -20,6 +21,8 @@ mod runner {
     use tokio::fs;
     use wasm_component_trampoline::{CompositionGraph, GuestCall, GuestResult, Trampoline};
     use wasmtime::{Config, Engine, Store, component::Linker};
+
+    use runner::cli::Args;
 
     wasmtime::component::bindgen!({
         path: "../wasm/application/wit",
@@ -99,6 +102,8 @@ mod runner {
     }
 
     pub async fn main() -> anyhow::Result<()> {
+        let _args = Args::parse();
+
         let verbose = false; // TODO(bill): command line option
         // Configure the WebAssembly engine
         let mut config = Config::new();

--- a/tests/runner/src/bin/runner.rs
+++ b/tests/runner/src/bin/runner.rs
@@ -15,7 +15,7 @@ mod runner {
     use anyhow::Error;
     use clap::Parser;
     use semver::Version;
-    use std::path::Path;
+    use std::path::PathBuf;
 
     use std::sync::Arc;
     use tokio::fs;
@@ -66,28 +66,22 @@ mod runner {
         }
     }
 
-    // TODO(bill): directory from command line
-    const WASM_DIR: &str = "wasm32-unknown-unknown/release/";
-
-    // TODO(bill): packages from command line
     async fn add_package(
         graph: &mut CompositionGraph<AppData>,
+        wasm_dir: &PathBuf,
         path: &str,
         name: &str,
         version: Version,
     ) -> Result<wasm_component_trampoline::PackageId, wasm_component_trampoline::AddPackageError>
     {
         eprintln!("Loading {path} component...");
-        let wasm_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .join("target")
-            .join(WASM_DIR);
+
         let wasm_file = format!("{path}.component.wasm").to_string();
         let pkg_bytes = fs::read(wasm_dir.join(&wasm_file))
             .await
             .unwrap_or_else(|_| {
                 panic!(
-                    "Failed to read {}/{wasm_file} Make sure it's been compiled",
+                    "failed to read {}/{wasm_file}; make sure it's been compiled!",
                     wasm_dir.display()
                 )
             });
@@ -102,9 +96,8 @@ mod runner {
     }
 
     pub async fn main() -> anyhow::Result<()> {
-        let _args = Args::parse();
+        let args = Args::parse();
 
-        let verbose = false; // TODO(bill): command line option
         // Configure the WebAssembly engine
         let mut config = Config::new();
         config.wasm_component_model(true);
@@ -128,18 +121,38 @@ mod runner {
         let mut graph = CompositionGraph::<AppData>::new();
 
         // Load the logger component
-        add_package(&mut graph, "logger", "test:logging", Version::new(1, 1, 1)).await?;
-        add_package(&mut graph, "logger", "test:logging", Version::new(1, 1, 1))
-            .await
-            .expect_err("Duplicate logger component should not be allowed");
+        add_package(
+            &mut graph,
+            &args.wasm_dir,
+            "logger",
+            "test:logging",
+            Version::new(1, 1, 1),
+        )
+        .await?;
+        add_package(
+            &mut graph,
+            &args.wasm_dir,
+            "logger",
+            "test:logging",
+            Version::new(1, 1, 1),
+        )
+        .await
+        .expect_err("Duplicate logger component should not be allowed");
 
         // Load the KV store component
-        let _kvstore_id =
-            add_package(&mut graph, "kvstore", "test:kvstore", Version::new(2, 1, 6)).await?;
+        let _kvstore_id = add_package(
+            &mut graph,
+            &args.wasm_dir,
+            "kvstore",
+            "test:kvstore",
+            Version::new(2, 1, 6),
+        )
+        .await?;
 
         // Load the application component
         let app_id = add_package(
             &mut graph,
+            &args.wasm_dir,
             "application",
             "test:application",
             Version::new(0, 4, 0),
@@ -148,7 +161,7 @@ mod runner {
 
         // Instantiate the components
         eprintln!("Instantiating components...");
-        if verbose {
+        if args.verbose {
             eprintln!("graph: {graph:#?}");
         }
 

--- a/tests/runner/src/cli.rs
+++ b/tests/runner/src/cli.rs
@@ -1,0 +1,5 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {}

--- a/tests/runner/src/cli.rs
+++ b/tests/runner/src/cli.rs
@@ -1,5 +1,15 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
-pub struct Args {}
+pub struct Args {
+    /// WASM build artifacts directory
+    #[arg(short, long, required = true)]
+    pub wasm_dir: PathBuf,
+
+    /// Show verbose logging
+    #[arg(short, long)]
+    pub verbose: bool,
+}

--- a/tests/runner/src/lib.rs
+++ b/tests/runner/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod cli;


### PR DESCRIPTION
This is to facilitate easier handling for passing a WASM artifacts directory from a Nix flake check when migrating over the devenv testing scripts.